### PR TITLE
Add timing information to the output

### DIFF
--- a/lib/rspec_flat_error_formatter.rb
+++ b/lib/rspec_flat_error_formatter.rb
@@ -55,9 +55,8 @@ class RspecFlatErrorFormatter < RSpec::Core::Formatters::BaseTextFormatter
     output.puts formatted
   end
 
-  def dump_summary(_notification)
-    # TODO: Finished in 0.34138 seconds (files took 0.26296 seconds to load) (copy from BaseFormatter)
-    # TODO: 1 example, 0 failures (copy from BaseFormatter)
+  def dump_summary(notification)
+    output.puts "\nFinished in #{notification.formatted_duration} (files took #{notification.formatted_load_time} to load)."
   end
 
   protected

--- a/spec/rspec_flat_error_formatter_spec.rb
+++ b/spec/rspec_flat_error_formatter_spec.rb
@@ -57,6 +57,10 @@ describe RspecFlatErrorFormatter do
     it 'outputs correct progress info for the entire test suite' do
       expect(example_spec_output_lines).to include('.**FFFFFFFFFF')
     end
+
+    it 'outputs the timing information' do
+      expect(example_spec_output).to match(/Finished in \d+.\d+ seconds \(files took \d+.\d+ seconds to load\)./)
+    end
   end
 
   describe 'pending examples' do


### PR DESCRIPTION
This commit adds timing information (how much time it took to load the
file and how much time it took to run the suite) into the output of the
formatter.

Closes #4